### PR TITLE
Traducción del README al inglés - README translation to English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
-# Study Planner Pro
+# Study Planner Pro 🚀
 
-Aplicação completa de planejamento de estudos com frontend em React + Tailwind CSS e backend em Java + Spring Boot.
+[![Frontend](https://img.shields.io/badge/React-19.2-blue?logo=react)](https://reactjs.org/)
+[![Backend](https://img.shields.io/badge/Java-11-orange?logo=java)](https://www.java.com/)
+[![Spring Boot](https://img.shields.io/badge/Spring_Boot-2.7.18-green?logo=spring)](https://spring.io/projects/spring-boot)
+[![License](https://img.shields.io/badge/License-Apache%202-blue)](LICENSE)
+
+Aplicación completa de planificación de estudios con **frontend en React + Tailwind CSS** y **backend en Java + Spring Boot**.
 
 ## Estrutura do Projeto
 
@@ -23,7 +28,7 @@ study-planner/
 - Maven
 
 ### Frontend
-- React 19.2.0
+- React 19.2
 - Vite 7.2.4
 - Tailwind CSS 4.1.17
 - React Router DOM

--- a/README.md
+++ b/README.md
@@ -15,37 +15,36 @@ study-planner/
 └── frontend/         # Interface em React + Tailwind CSS
 ```
 
-## Tecnologias
+## 🛠 Tecnologías
 
 ### Backend
-- Java 11
-- Spring Boot 2.7.18
-- Spring Web
-- Spring Data JPA
-- Spring Security
-- H2 Database (em memória)
-- Lombok
-- Maven
+- **Java 11**
+- **Spring Boot 2.7**  
+- **Spring Web** (para crear la API REST)  
+- **Spring Data JPA** (para acceso a la base de datos)  
+- **Spring Security** (autenticación y autorización)  
+- **H2 Database** (en memoria para desarrollo)  
+- **Lombok** (reducción de boilerplate)  
+- **Maven** (gestión de dependencias y build)
 
 ### Frontend
-- React 19.2
-- Vite 7.2.4
-- Tailwind CSS 4.1.17
-- React Router DOM
-- Axios
-- Recharts
-- Lucide React
+- **React 19.2** (librería para la interfaz de usuario)  
+- **Vite 7.2** (bundler rápido para desarrollo)  
+- **Tailwind CSS 4.1** (framework CSS para diseño responsivo)  
+- **React Router DOM** (navegación entre páginas)  
+- **Axios** (peticiones HTTP a la API)  
+- **Recharts** (gráficos y estadísticas)  
+- **Lucide React** (iconos modernos)
 
-## Como Executar
+
+## ⚡ Instalación Rápida
 
 ### Backend
-
 ```bash
 cd backend
 ./mvnw spring-boot:run
+# Backend disponible en: http://localhost:8080
 ```
-
-O backend estará disponível em: `http://localhost:8080`
 
 ### Frontend
 
@@ -53,61 +52,77 @@ O backend estará disponível em: `http://localhost:8080`
 cd frontend
 pnpm install
 pnpm dev
+# Frontend disponible en: http://localhost:5173
 ```
 
 O frontend estará disponível em: `http://localhost:5173`
 
-## Funcionalidades
+## 🎯 Funcionalidades
 
-- ✅ Autenticação (Login/Registro)
-- ✅ Dashboard com estatísticas
-- ✅ Gráfico de horas de estudo
-- ✅ Sessões de estudo recentes
-- ✅ Metas ativas com progresso
-- ✅ Gerenciamento de matérias
-- ✅ API REST completa
-- ✅ Design responsivo e tema escuro
+- ✅ Autenticación (Login / Registro)  
+- ✅ Dashboard con estadísticas  
+- ✅ Gráficos de horas de estudio  
+- ✅ Sesiones de estudio recientes  
+- ✅ Metas activas con progreso  
+- ✅ Gestión de materias  
+- ✅ API REST completa  
+- ✅ Diseño responsivo y tema oscuro  
 
-## Endpoints da API
+![Dashboard Screenshot](./frontend/src/assets/dashboard.png)  
+*Ejemplo de Dashboard de Study Planner Pro*
 
-### Autenticação
-- `POST /api/auth/register` - Registrar usuário
-- `POST /api/auth/login` - Fazer login
 
-### Dashboard
-- `GET /api/dashboard/stats/{userId}` - Estatísticas do usuário
+## 🔗 Endpoints de la API
 
-### Sessões de Estudo
-- `GET /api/study-sessions/user/{userId}` - Listar sessões
-- `GET /api/study-sessions/user/{userId}/recent` - Sessões recentes
-- `POST /api/study-sessions` - Criar sessão
-- `DELETE /api/study-sessions/{id}` - Deletar sessão
+| Funcionalidad          | Endpoint                                 | Método |
+|------------------------|-----------------------------------------|--------|
+| Registrar usuario       | /api/auth/register                       | POST   |
+| Iniciar sesión          | /api/auth/login                          | POST   |
+| Estadísticas del usuario| /api/dashboard/stats/{userId}           | GET    |
+| Listar sesiones         | /api/study-sessions/user/{userId}       | GET    |
+| Listar sesiones recientes| /api/study-sessions/user/{userId}/recent| GET    |
+| Crear sesión            | /api/study-sessions                     | POST   |
+| Eliminar sesión         | /api/study-sessions/{id}                | DELETE |
+| Listar metas            | /api/goals/user/{userId}                | GET    |
+| Crear meta              | /api/goals                              | POST   |
+| Actualizar meta         | /api/goals/{id}                         | PUT    |
+| Eliminar meta           | /api/goals/{id}                         | DELETE |
+| Listar materias         | /api/subjects/user/{userId}             | GET    |
+| Crear materia           | /api/subjects                           | POST   |
+| Eliminar materia        | /api/subjects/{id}                      | DELETE |
 
-### Metas
-- `GET /api/goals/user/{userId}` - Listar metas
-- `POST /api/goals` - Criar meta
-- `PUT /api/goals/{id}` - Atualizar meta
-- `DELETE /api/goals/{id}` - Deletar meta
 
-### Matérias
-- `GET /api/subjects/user/{userId}` - Listar matérias
-- `POST /api/subjects` - Criar matéria
-- `DELETE /api/subjects/{id}` - Deletar matéria
+## 🗄 Base de Datos
 
-## Banco de Dados
+- **H2 Database** en memoria (para desarrollo)  
+- Console H2: `http://localhost:8080/h2-console`  
+- JDBC URL: `jdbc:h2:mem:studyplanner`  
+- Usuario: `sa`  
+- Contraseña: (vacío)  
 
-O projeto usa H2 Database em memória para desenvolvimento. Para implementar persistência, configure um banco de dados como PostgreSQL ou MySQL no `application.properties`.
+> Para usar un **banco de datos persistente** (PostgreSQL / MySQL), configure `application.properties` y cambie `spring.jpa.hibernate.ddl-auto` a `update`.
 
-Console H2: `http://localhost:8080/h2-console`
-- JDBC URL: `jdbc:h2:mem:studyplanner`
-- Username: `sa`
-- Password: (vazio)
 
-## Próximos Passos
+## 🤝 Contribuciones
 
-Para implementar o banco de dados persistente:
+1. Hacer fork del repositorio  
+2. Crear una rama de función: `feature/mi-funcion`  
+3. Hacer commit de los cambios  
+4. Abrir un Pull Request
 
-1. Adicionar dependência do PostgreSQL/MySQL no `pom.xml`
-2. Atualizar `application.properties` com configurações do banco
-3. Alterar `spring.jpa.hibernate.ddl-auto` para `update`
-4. Executar migrations se necessário
+## 🚀 Próximos Pasos
+
+- Implementar base de datos persistente  
+- Mejorar tests  
+- Añadir más estadísticas y gráficos
+
+### 📸 Capturas de Pantalla
+
+![Pantalla de Inicio](./frontend/src/assets/home.png)  
+*Vista de la pantalla principal de Study Planner Pro*
+
+![Vista de Sesiones](./frontend/src/assets/sessions.png)  
+*Listado de sesiones de estudio recientes*
+
+![Vista de Metas](./frontend/src/assets/goals.png)  
+*Seguimiento de metas activas con progreso*

--- a/README.md
+++ b/README.md
@@ -5,46 +5,49 @@
 [![Spring Boot](https://img.shields.io/badge/Spring_Boot-2.7.18-green?logo=spring)](https://spring.io/projects/spring-boot)
 [![License](https://img.shields.io/badge/License-Apache%202-blue)](LICENSE)
 
-Aplicación completa de planificación de estudios con **frontend en React + Tailwind CSS** y **backend en Java + Spring Boot**.
+A complete study-planning application with a **React + Tailwind CSS frontend** and a **Java + Spring Boot backend**.
 
-## Estrutura do Projeto
+## Project Structure
+
 
 ```
 study-planner/
-├── backend/          # API REST em Java + Spring Boot
-└── frontend/         # Interface em React + Tailwind CSS
+├── backend/ # REST API  in Java + Spring Boot
+└── frontend/ # Interface in React + Tailwind CSS
 ```
 
-## 🛠 Tecnologías
+
+## 🛠 Technologies
 
 ### Backend
 - **Java 11**
-- **Spring Boot 2.7**  
-- **Spring Web** (para crear la API REST)  
-- **Spring Data JPA** (para acceso a la base de datos)  
-- **Spring Security** (autenticación y autorización)  
-- **H2 Database** (en memoria para desarrollo)  
-- **Lombok** (reducción de boilerplate)  
-- **Maven** (gestión de dependencias y build)
+- **Spring Boot 2.7**
+- **Spring Web** (to create the REST API)
+- **Spring Data JPA** (for database access)
+- **Spring Security** (authentication & authorization)
+- **H2 Database** (in-memory for development)
+- **Lombok** (reduces boilerplate)
+- **Maven** (dependency & build management)
 
 ### Frontend
-- **React 19.2** (librería para la interfaz de usuario)  
-- **Vite 7.2** (bundler rápido para desarrollo)  
-- **Tailwind CSS 4.1** (framework CSS para diseño responsivo)  
-- **React Router DOM** (navegación entre páginas)  
-- **Axios** (peticiones HTTP a la API)  
-- **Recharts** (gráficos y estadísticas)  
-- **Lucide React** (iconos modernos)
+- **React 19.2** (UI library)
+- **Vite 7.2** (fast development bundler)
+- **Tailwind CSS 4.1** (responsive CSS framework)
+- **React Router DOM** (page navigation)
+- **Axios** (API HTTP requests)
+- **Recharts** (charts and statistics)
+- **Lucide React** (modern icons)
 
-
-## ⚡ Instalación Rápida
+## ⚡ Quick Installation
 
 ### Backend
+
 ```bash
 cd backend
 ./mvnw spring-boot:run
-# Backend disponible en: http://localhost:8080
+# Backend available at: http://localhost:8080
 ```
+
 
 ### Frontend
 
@@ -52,77 +55,82 @@ cd backend
 cd frontend
 pnpm install
 pnpm dev
-# Frontend disponible en: http://localhost:5173
+# Frontend available at: http://localhost:5173
 ```
 
-O frontend estará disponível em: `http://localhost:5173`
+The frontend will be available at: `http://localhost:5173`
 
-## 🎯 Funcionalidades
+## 🎯 Features
 
-- ✅ Autenticación (Login / Registro)  
-- ✅ Dashboard con estadísticas  
-- ✅ Gráficos de horas de estudio  
-- ✅ Sesiones de estudio recientes  
-- ✅ Metas activas con progreso  
-- ✅ Gestión de materias  
-- ✅ API REST completa  
-- ✅ Diseño responsivo y tema oscuro  
+- ✅ **Authentication** (Login / Register)
+- ✅ **Dashboard with user statistics**
+- ✅ **Study-hours charts**
+- ✅ **Recent study sessions**
+- ✅ **Active goals with progress tracking**
+- ✅ **Subject management**
+- ✅ **Full REST API**
+- ✅ **Responsive design**
+- ✅ **Dark mode support**
 
-![Dashboard Screenshot](./frontend/src/assets/dashboard.png)  
-*Ejemplo de Dashboard de Study Planner Pro*
-
-
-## 🔗 Endpoints de la API
-
-| Funcionalidad          | Endpoint                                 | Método |
-|------------------------|-----------------------------------------|--------|
-| Registrar usuario       | /api/auth/register                       | POST   |
-| Iniciar sesión          | /api/auth/login                          | POST   |
-| Estadísticas del usuario| /api/dashboard/stats/{userId}           | GET    |
-| Listar sesiones         | /api/study-sessions/user/{userId}       | GET    |
-| Listar sesiones recientes| /api/study-sessions/user/{userId}/recent| GET    |
-| Crear sesión            | /api/study-sessions                     | POST   |
-| Eliminar sesión         | /api/study-sessions/{id}                | DELETE |
-| Listar metas            | /api/goals/user/{userId}                | GET    |
-| Crear meta              | /api/goals                              | POST   |
-| Actualizar meta         | /api/goals/{id}                         | PUT    |
-| Eliminar meta           | /api/goals/{id}                         | DELETE |
-| Listar materias         | /api/subjects/user/{userId}             | GET    |
-| Crear materia           | /api/subjects                           | POST   |
-| Eliminar materia        | /api/subjects/{id}                      | DELETE |
+![Dashboard Screenshot](./frontend/src/assets/dashboard.png)
+*Example of the Dashboard of Study Planner Pro*
 
 
-## 🗄 Base de Datos
+## 🔗 API Endpoints
 
-- **H2 Database** en memoria (para desarrollo)  
-- Console H2: `http://localhost:8080/h2-console`  
-- JDBC URL: `jdbc:h2:mem:studyplanner`  
-- Usuario: `sa`  
-- Contraseña: (vacío)  
+| Functionality | Endpoint | Method |
+|------------------------|------------------------------------------------|--------|
+| Register user | `/api/auth/register` | POST |
+| Log in | `/api/auth/login` | POST |
+| User statistics | `/api/dashboard/stats/{userId}` | GET |
+| List sessions | `/api/study-sessions/user/{userId}` | GET |
+| List recent sessions | `/api/study-sessions/user/{userId}/recent` | GET |
+| Create session | `/api/study-sessions` | POST |
+| Delete session | `/api/study-sessions/{id}` | DELETE |
+| List goals | `/api/goals/user/{userId}` | GET |
+| Create goal | `/api/goals` | POST |
+| Update goal | `/api/goals/{id}` | PUT |
+| Delete goal | `/api/goals/{id}` | DELETE |
+| List subjects | `/api/subjects/user/{userId}` | GET |
+| Create subject | `/api/subjects` | POST |
+| Delete subject | `/api/subjects/{id}` | DELETE |
 
-> Para usar un **banco de datos persistente** (PostgreSQL / MySQL), configure `application.properties` y cambie `spring.jpa.hibernate.ddl-auto` a `update`.
+
+## 🗄 Database
+
+- **H2 Database** (in-memory for development)
+- H2 Console: `http://localhost:8080/h2-console`
+- JDBC URL: `jdbc:h2:mem:studyplanner`
+- User: `sa`
+- Password: *(empty)*
+
+> To use a **persistent database** (PostgreSQL / MySQL), update your `application.properties` and set:
+> ```
+> spring.jpa.hibernate.ddl-auto=update
+> ```
+
+## 🤝 Contributions
+
+1. Fork the repository
+2. Create a feature branch: `feature/my-feature`
+3. Commit your changes
+4. Open a Pull Request
 
 
-## 🤝 Contribuciones
+## 🚀 Next Steps
 
-1. Hacer fork del repositorio  
-2. Crear una rama de función: `feature/mi-funcion`  
-3. Hacer commit de los cambios  
-4. Abrir un Pull Request
+- Implement a persistent database
+- Improve test coverage
+- Add more statistics and charts
 
-## 🚀 Próximos Pasos
 
-- Implementar base de datos persistente  
-- Mejorar tests  
-- Añadir más estadísticas y gráficos
+## 📸 Screenshots
 
-### 📸 Capturas de Pantalla
+![Home Screen](./frontend/src/assets/home.png)
+*Main screen view of Study Planner Pro*
 
-![Pantalla de Inicio](./frontend/src/assets/home.png)  
-*Vista de la pantalla principal de Study Planner Pro*
+![Sessions View](./frontend/src/assets/sessions.png)
+*List of recent study sessions*
 
-![Vista de Sesiones](./frontend/src/assets/sessions.png)  
-*Listado de sesiones de estudio recientes*
-
-![Vista de Metas](./frontend/src/assets/goals.png)  
-*Seguimiento de metas activas con progreso*
+![Goals View](./frontend/src/assets/goals.png)
+*Tracking of active goals with progress*


### PR DESCRIPTION
## 🔄 Resumen de Cambios

- Se tradujo todo el contenido del README del español/portugués al inglés.
- Se reestructuraron todas las secciones en Markdown limpio y listo para copiar/pegar.
- Se mejoró la consistencia en títulos, listas y formato general.
- Se actualizaron términos para mayor claridad (ej. “metas”, “sesiones”, “estadísticas”).
- Se entregaron bloques de Markdown individuales para:
  - Características (Features)
  - Endpoints de la API
  - Configuración de la base de datos
  - Contribuciones
  - Próximos pasos
  - Capturas de pantalla
- Se aseguró un estilo uniforme en todas las secciones (encabezados con emojis, tablas, bloques de código).
